### PR TITLE
fix detection of M4RI version when configure --with-m4ri is used

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,8 @@
 
 SUBDIRS=lela util macros tests doc
 
+ACLOCAL_AMFLAGS = -I macros
+
 bin_SCRIPTS=lela-config
 
 DISTCLEANFILES=_configs.sed

--- a/configure.in
+++ b/configure.in
@@ -24,8 +24,6 @@ AM_OUTPUT_DEPENDENCY_COMMANDS
 CFLAGS=${CFLAGS:-$DEFAULT_CFLAGS}
 CXXFLAGS=${CXXFLAGS:-$DEFAULT_CFLAGS}
 
-AM_ACLOCAL_INCLUDE(macros)
-
 # work around to fix the backward compatibility issue of automake 1.10 with 1.9 (pb with MKDIR_P)
 AC_SUBST([MKDIR_P])
 AC_PROG_CC

--- a/macros/m4ri-check.m4
+++ b/macros/m4ri-check.m4
@@ -112,7 +112,7 @@ if test "x$m4ri_found" = "xyes" ; then
    	AC_MSG_CHECKING(whether version of M4RI is at least 20110601)
 	AC_LANG([C])
 	BACKUP_CFLAGS=${CFLAGS}
-	CFLAGS="${CFLAGS} -std=c99"
+	CFLAGS="${CFLAGS} -std=c99 -I${M4RI_HOME}/include"
 	AC_COMPILE_IFELSE(
 		AC_LANG_PROGRAM([#include <m4ri/m4ri.h>],[mzd_t M; wi_t i = M.rowstride;]),
 		[m4ri_new_version=yes],


### PR DESCRIPTION
Hi, I fixed the detection of M4RI's version but for that I also had to fix some minor issues in configure.in and Makefile.am 
