### PR TITLE
fix gcc 4.7 error: 'read' was not declared in this scope

### DIFF
--- a/lela/randiter/mersenne-twister.C
+++ b/lela/randiter/mersenne-twister.C
@@ -24,6 +24,7 @@
 #include "lela/lela-config.h"
 
 #include <fcntl.h>
+#include <unistd.h>
 
 #include "lela/randiter/mersenne-twister.h"
 #include "lela/util/debug.h"


### PR DESCRIPTION
Make fails with gcc 4.7 with the error 

mersenne-twister.C: In static member function 'static int LELA::MersenneTwister::getSeed()':
mersenne-twister.C:235:29: error: 'read' was not declared in this scope
mersenne-twister.C:238:10: error: 'close' was not declared in this scope

Adding #include < unistd.h > fixes this
