### PR TITLE
fix to .gitignore on Cygwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ util/diff
 util/is-zero
 util/submatrix
 util/row-echelon-form
+util/*.exe # for Windows
 macros/libtool.m4
 macros/ltoptions.m4
 macros/ltsugar.m4


### PR DESCRIPTION
I updated .gitignore to ignore .exe files in util/
These are produced when compiling LELA on Cygwin.

(this is really just a test of how to do fork-edit-push-pull request on github, but I figured I might as well have the change be actually useful as well)
