### PR TITLE
Fixes for Cygwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ util/diff
 util/is-zero
 util/submatrix
 util/row-echelon-form
-util/*.exe # for Windows
 macros/libtool.m4
 macros/ltoptions.m4
 macros/ltsugar.m4
@@ -112,3 +111,7 @@ doc/reference.xml
 doc/xml
 doc/boost*bz2
 doc/doxy.debug
+
+# for Cygwin on Windows
+util/*.exe
+tests/*.exe

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,8 +10,8 @@ BENCHMARK_CXXFLAGS = -O2
 
 SUBDIRS = data
 
-AM_CPPFLAGS= $(GMP_CFLAGS) $(PNG_CFLAGS) $(M4RI_CFLAGS)
-LDADD = $(GMP_LIBS)  $(PNG_LIBS) $(M4RI_LIBS) $(BLAS_LIBS) $(top_builddir)/lela/liblela.la
+AM_CPPFLAGS = $(GMP_CFLAGS) $(PNG_CFLAGS) $(M4RI_CFLAGS)
+LDADD = $(top_builddir)/lela/liblela.la $(M4RI_LIBS) $(BLAS_LIBS) $(PNG_LIBS) $(GMP_LIBS)
 
 # Put an entry for your test-mycomponent.C here (or in one of the other test groups).  
 # Don't forget to add a test_mycomponent_SOURCES entry below.


### PR DESCRIPTION
Further fix to .gitignore and fix to make the tests build on Cygwin.
